### PR TITLE
Configure gh-pages asset paths

### DIFF
--- a/app/changeWAY/page.tsx
+++ b/app/changeWAY/page.tsx
@@ -5,6 +5,8 @@ import Header from '../../src/components/Header';
 import Footer from '../../src/components/Footer';
 import { useState } from 'react';
 
+const prefix = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 export default function ChangeWAY() {
   const router = useRouter();
 
@@ -13,7 +15,7 @@ export default function ChangeWAY() {
       id: 1,
       title: 'Já sou cliente',
       description: 'Já sou cliente do escritório e quero adicionar os documentos novos solicitados.',
-      image: '/law-card-2.jpg',
+      image: `${prefix}/law-card-2.jpg`,
       buttonText: 'Enviar Documentos',
       redirect: '/cliente', // Adicione a rota aqui
     },
@@ -21,7 +23,7 @@ export default function ChangeWAY() {
       id: 2,
       title: 'Sou novo cliente',
       description: 'Sou novo cliente do escritório e quero enviar meus documentos para análise de caso.',
-      image: '/law-card-9.webp',
+      image: `${prefix}/law-card-9.webp`,
       buttonText: 'Enviar Documentos',
       redirect: '/novoCliente', // Adicione a rota aqui
     },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@
 import './globals.css';
 import { ReduxProvider } from '../store/provider';
 
+const prefix = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 export const metadata = {
   title: 'Alcides e Mosinho',
   description: 'Aplicação web de Alcides e Mosinho',
@@ -17,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             position: 'fixed',
             inset: 0,
             zIndex: 0,
-            backgroundImage: "url('/images/3.jpg')",
+            backgroundImage: `url('${prefix}/images/3.jpg')`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
             width: '100vw',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,6 +54,8 @@ import { motion, AnimatePresence } from 'framer-motion';
 import Header from '../src/components/Header';
 import Footer from '../src/components/Footer';
 
+const prefix = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 export default function Inicio() {
   const [startTransition, setStartTransition] = useState(false);
   const [showLayout, setShowLayout] = useState(false);
@@ -84,7 +86,7 @@ export default function Inicio() {
     <div
       className="min-h-screen flex flex-col bg-cover bg-center bg-no-repeat"
       style={{
-        backgroundImage: `url('/background-law.jpg')`, // substitua pelo caminho correto da imagem
+        backgroundImage: `url('${prefix}/images/background2.jpg')`,
       }}
     >
       <AnimatePresence>

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+  trailingSlash: true,
+  env: {
+    NEXT_PUBLIC_BASE_PATH: isProd ? `/${repo}` : "",
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add public base path env for gh-pages
- prefix static asset URLs with this path
- ensure exported pages use trailing slashes

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688198e8f6a0832c8ddf4fa358903989