### PR TITLE
Update error handling for fetch failures

### DIFF
--- a/app/cliente/page.tsx
+++ b/app/cliente/page.tsx
@@ -115,7 +115,11 @@ export default function Cliente() {
     } catch (error: any) {
       console.log("error", error);
       setErrorMessage(error.message || "Erro desconhecido");
-      setCurrentStep(5);
+      if (error.message && error.message.includes("Failed to fetch")) {
+        setCurrentStep(4);
+      } else {
+        setCurrentStep(5);
+      }
     } finally {
       setLoading(false);
     }

--- a/app/novoCliente/page.tsx
+++ b/app/novoCliente/page.tsx
@@ -309,7 +309,11 @@ export default function NovoCliente() {
     } catch (error: any) {
       console.log("error", error);
       setErrorMessage(error.message || "Erro desconhecido");
-      setCurrentStep(6);
+      if (error.message && error.message.includes("Failed to fetch")) {
+        setCurrentStep(5);
+      } else {
+        setCurrentStep(6);
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- treat `Failed to fetch` errors as a success in client pages

## Testing
- `npm run lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68830eec5de4832c98a5390699eaa5cd