### PR TITLE
Handle load failed as fetch error

### DIFF
--- a/app/novoCliente/page.tsx
+++ b/app/novoCliente/page.tsx
@@ -309,8 +309,16 @@ export default function NovoCliente() {
     } catch (error: any) {
       console.log("error", error);
       setErrorMessage(error.message || "Erro desconhecido");
-      if (error.message && error.message.includes("Failed to fetch")) {
-        setCurrentStep(5);
+      if (error.message) {
+        const normalized = error.message.toLowerCase();
+        if (
+          normalized.includes("failed to fetch") ||
+          normalized.includes("load failed")
+        ) {
+          setCurrentStep(5);
+        } else {
+          setCurrentStep(6);
+        }
       } else {
         setCurrentStep(6);
       }


### PR DESCRIPTION
## Summary
- consider `load failed` as success when handling upload errors

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6883d05e35dc832c98bf4cc1950ebf5c